### PR TITLE
Fix development page link in 2015-11-09 post

### DIFF
--- a/source/_posts/2015-11-09-PHP-Version-Updates.twig
+++ b/source/_posts/2015-11-09-PHP-Version-Updates.twig
@@ -35,7 +35,7 @@ authors:
 
         <h3>Development Package!</h3>
 
-        We have created a development package [phergie/phergie-irc-bot-react-development](https://github.com/phergie/phergie-irc-bot-react-development) to hold all of our commonly used development dependencies and have begun updating packages to use this.
+        We have created a development package <a href="https://github.com/phergie/phergie-irc-bot-react-development">phergie/phergie-irc-bot-react-development</a> to hold all of our commonly used development dependencies and have begun updating packages to use this.
 
         Instead of requiring multiple dependencies for development you can require this one package instead.
     </div>


### PR DESCRIPTION
Markdown isn't being interpreted, change it to an HTML link.